### PR TITLE
Revert back to gangway 3.1.0 commandline.tmpl

### DIFF
--- a/gangway/commandline.tmpl
+++ b/gangway/commandline.tmpl
@@ -829,14 +829,14 @@
         <code class="language-bash">
 echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
 kubectl config set-cluster {{ .ClusterName }} --server={{ .APIServerURL }} --certificate-authority=ca-{{ .ClusterName }}.pem --embed-certs
-kubectl config set-credentials {{ .KubeCfgUser }}  \
+kubectl config set-credentials {{ .Email }}  \
 --auth-provider=oidc  \
 --auth-provider-arg='idp-issuer-url={{ .IssuerURL }}'  \
 --auth-provider-arg='client-id={{ .ClientID }}'  \
 --auth-provider-arg='client-secret={{ .ClientSecret }}' \
 --auth-provider-arg='refresh-token={{ .RefreshToken }}' \
 --auth-provider-arg='id-token={{ .IDToken }}'
-kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .KubeCfgUser }}
+kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }}
 kubectl config use-context {{ .ClusterName }}
 rm ca-{{ .ClusterName }}.pem
         </code>


### PR DESCRIPTION
Since we do not bump gangway version to `3.2.0`, revert to `3.1.0` command-line template.

Reference: https://github.com/heptiolabs/gangway/pull/129/files#diff-9d38691315575199be3645e23a786e77